### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,6 +3,7 @@ author=Lorenzo Romagnoli
 email=lorenzormgnl@gmail.com
 sentence=Easily connect the Arduino Yun to socket.io server
 paragraph=This library was developed to enable you to easily connect the Arduino Yun to socket.io server. 
+category=Communication
 url=https://github.com/lorenzoromagnoli/SocketIOYunClient
 architectures=avr
 version=1.0


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library SocketIOYunClient is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6 and 1.6.7. If you disagree with my category choice I'm happy to change the category to any of the other [valid category values](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification) and squash to a single commit.
